### PR TITLE
Cosmetic fix in gemspec

### DIFF
--- a/ruby-processing.gemspec
+++ b/ruby-processing.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.authors = ["Jeremy Ashkenas", "Peter Gassner", "Martin Stannard", "Andrew Nanton",
                "Marc Chung", "Peter Krenn", "Florian Jenett", "Andreas Haller",
                "Juris Galang"]
-  s.date = "2010-3-4"
+  s.date = "2010-03-04"
   s.default_executable = "rp5"
   s.email = "jeremy@ashkenas.com"
   s.executables = ["rp5"]


### PR DESCRIPTION
Just had this error while building gem:
    Invalid gemspec in [ruby-processing.gemspec]: invalid date format in specification: "2010-3-4"
    ERROR:  Error loading gemspec. Aborting.
    rake aborted!
Had to put in extra zeros. Guess not all systems understand this not-so-strict date format. 
