### PR TITLE
Bug on starting rp5 on Windows 7

### DIFF
--- a/lib/ruby-processing/library_loader.rb
+++ b/lib/ruby-processing/library_loader.rb
@@ -126,7 +126,7 @@ module Processing
       if sketchbook_path = CONFIG["sketchbook_path"]
         return File.expand_path(sketchbook_path)
       else
-        ["Application Data/Processing", "AppData/Roaming/Processing", 
+        ["'Application Data/Processing'", "AppData/Roaming/Processing", 
          "Library/Processing", "Documents/Processing", 
          ".processing", "sketchbook"].each do |prefix|
           path = "#{ENV["HOME"]}/#{prefix}"


### PR DESCRIPTION
On windows 7, rp5 fails to start because of a space in a directory name (Application data). See issue #38. With this modification, it's OK.

C:\Code\scketchbook> rp5 run .\samples\anar\extrusion.rb
Errno::ENOENT: No such file or directory - C:/Users/clem/Application Data/Processing
directory? at org/jruby/RubyFileTest.java:102
directory? at org/jruby/RubyFileTest.java:87
directory? at org/jruby/RubyFileTest.java:78
test at org/jruby/RubyKernel.java:1480
find_sketchbook_path at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/library_loader.rb:137
each at org/jruby/RubyArray.java:1612
find_sketchbook_path at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/library_loader.rb:129
initialize at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/library_loader.rb:6
App at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/app.rb:92
Processing at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/app.rb:28
(root) at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/app.rb:18
require at org/jruby/RubyKernel.java:1038
(root) at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/app.rb:6
require at org/jruby/RubyKernel.java:1038
(root) at C:/Ruby192/lib/ruby/gems/1.9.1/gems/ruby-processing-1.0.11/lib/ruby-processing/runners/run.rb:5
