### PR TITLE
Fix reference link

### DIFF
--- a/README
+++ b/README
@@ -56,7 +56,7 @@
   smooth, text_align, translate, triangle...
   
   And so on, and so forth. See the full list here: 
-  http://www.processing.org/reference/index_ext.html
+  http://www.processing.org/reference/
   
   ~ How can I learn more? ~
 


### PR DESCRIPTION
The reference link no longer works - I believe this is the same content as was originally being linked.

If this is merged, I'll update the wiki front page too.
