### PR TITLE
Add UTF-8 magic comment to be able to use non ascii characters in a sketch

### DIFF
--- a/lib/ruby-processing/runners/base.rb
+++ b/lib/ruby-processing/runners/base.rb
@@ -1,3 +1,5 @@
+# -*- encoding : utf-8 -*-
+
 $LOAD_PATH << File.expand_path(File.dirname(__FILE__) + "/../../")
 SKETCH_PATH = ARGV.shift unless defined? SKETCH_PATH
 SKETCH_ROOT = File.dirname(SKETCH_PATH) unless defined? SKETCH_ROOT


### PR DESCRIPTION
When running a sketch with non ascii characters  a "invalid multibyte char (US-ASCII)" error is raised by ruby.
