### PR TITLE
Fix export on linux, and remove eval hack from base_exporter

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v2.5.1 Some fixes, and remove eval hack from base_exporter
+
 v2.5.0 Some refactoring, and a new install procedure
 * Some re-factoring of both code and examples, including
 * replacing the overuse of __FILE__ with 'relative_require'

--- a/lib/ruby-processing/exporters/base_exporter.rb
+++ b/lib/ruby-processing/exporters/base_exporter.rb
@@ -86,11 +86,13 @@ module Processing
         matchdata = code.match(/^.*[^::\.\w](require_relative|require|load)\b.*$/)
         break unless matchdata
         line = matchdata[0].gsub('__FILE__', "'#{@main_file_path}'")
-        line = line.gsub(/\b(require_relative|require|load)\b/, 'partial_paths << ')
-        eval(line)
-        where = "{#{local_dir}/,}{#{partial_paths.join(',')}}"
-        where += '.{rb,jar}' unless line =~ /\.[^.]+$/
-        requirements += Dir[where]
+        if (line =~ /\b(require_relative|require|load)\b/)
+          ln = line.gsub(/\b(require_relative|require|load)\b/, '') 
+          partial_paths << ln
+          where = "{#{local_dir}/,}{#{partial_paths.join(',')}}"
+          where += '.{rb,jar}' unless line =~ /\.[^.]+$/
+          requirements += Dir[where]
+        end
         code = matchdata.post_match
       end
       requirements

--- a/lib/ruby-processing/version.rb
+++ b/lib/ruby-processing/version.rb
@@ -1,3 +1,3 @@
 module RubyProcessing
-  VERSION = '2.5.0'
+  VERSION = '2.5.1'
 end

--- a/lib/templates/application/run.erb
+++ b/lib/templates/application/run.erb
@@ -1,5 +1,5 @@
 #!/bin/sh
-APPDIR=$(dirname '$0')
-export EXPORTED='true'
-cd '$APPDIR/lib'
-java -cp "<%= @linux_class_path %>" org.jruby.Main ../lib/ruby-processing/runners/run.rb <%= @main_file %>
+APPDIR=$(dirname "$0")
+export EXPORTED="true"
+cd "$APPDIR/lib"
+java -cp "<%= @linux_class_path %>" org.jruby.Main ruby-processing/runners/run.rb <%= @main_file %>


### PR DESCRIPTION
Changes to be committed:
    modified:   CHANGELOG
    modified:   lib/ruby-processing/exporters/base_exporter.rb
    modified:   lib/ruby-processing/version.rb
    modified:   lib/templates/application/run.erb
