### PR TITLE
Revert

### DIFF
--- a/ext/processing/vecmath/arcball/ArcballLibrary.java
+++ b/ext/processing/vecmath/arcball/ArcballLibrary.java
@@ -20,5 +20,4 @@ public class ArcballLibrary implements Library {
     public void load(final Ruby runtime, boolean wrap) throws IOException {
         Rarcball.createArcBall(runtime);
     }
-
 }

--- a/ext/processing/vecmath/arcball/JarcBall.java
+++ b/ext/processing/vecmath/arcball/JarcBall.java
@@ -16,7 +16,7 @@
  * 
  * 2) Simon Greenwold? 2003 (as reported 2006 by Tom Carden http://wiki.processing.org/w/Arcball)
  *
- * 3) JArcBall concept invented by Ken Shoemake, published in his 1985 SIGGRAPH paper "Animating rotations with quaternion curves". 
+ * 3) JarcBall concept invented by Ken Shoemake, published in his 1985 SIGGRAPH paper "Animating rotations with quaternion curves". 
  * 
  * 4) Somewhat modified by Martin Prout to support callbacks from processing sketch
  **/
@@ -27,22 +27,22 @@ import processing.event.KeyEvent;
 import processing.event.MouseEvent;
 
 /**
- * Supports the JArcBall and MouseWheel zoom manipulation of objects in
+ * Supports the JarcBall and MouseWheel zoom manipulation of objects in
  * processing
  * 
 * @author Martin Prout
  */
-public final class JArcBall {
+public final class JarcBall {
 
     private double center_x;
     private double center_y;
     private double radius;
-    private JVector v_down;
-    private JVector v_drag;
+    private Jvector v_down;
+    private Jvector v_drag;
     private Quaternion q_now;
     private Quaternion q_down;
     private Quaternion q_drag;
-    private JVector[] axisSet;
+    private Jvector[] axisSet;
     private Constrain axis;
     private boolean isActive = false;
     private final PApplet parent;
@@ -58,7 +58,7 @@ public final class JArcBall {
      * @param center_y double y coordinate of arcball center
      * @param radius double radius of arcball
      */
-    public JArcBall(final PApplet parent, float center_x, float center_y, float radius) {
+    public JarcBall(final PApplet parent, float center_x, float center_y, float radius) {
         this.zoomWheelHandler = new WheelHandler() {
             @Override
             public void handleWheel(final int delta) {
@@ -69,12 +69,12 @@ public final class JArcBall {
         this.center_x = center_x;
         this.center_y = center_y;
         this.radius = radius;
-        this.v_down = new JVector();
-        this.v_drag = new JVector();
+        this.v_down = new Jvector();
+        this.v_drag = new Jvector();
         this.q_now = new Quaternion();
         this.q_down = new Quaternion();
         this.q_drag = new Quaternion();
-        this.axisSet = new JVector[]{new JVector(1.0, 0.0, 0.0), new JVector(0.0, 1.0, 0.0), new JVector(0.0, 0.0, 1.0)};
+        this.axisSet = new Jvector[]{new Jvector(1.0, 0.0, 0.0), new Jvector(0.0, 1.0, 0.0), new Jvector(0.0, 0.0, 1.0)};
         this.axis = Constrain.FREE; // no constraints...
 
     }
@@ -85,7 +85,7 @@ public final class JArcBall {
      * @param parent
      *
      */
-    public JArcBall(final PApplet parent) {
+    public JarcBall(final PApplet parent) {
         // this(parent, parent.width / 2.0f, parent.height / 2.0f, Math.min(parent.width, parent.height) * 0.5f);
         this(parent, 0, 0, Math.min(parent.width, parent.height) * 0.8f);
         parent.camera(parent.width / 2.0f, parent.height / 2.0f, parent.height * DEPTH, 0, 0, 0, 0, 1.0f, 0);
@@ -188,14 +188,14 @@ public final class JArcBall {
     }
 
     /**
-     * Returns either the JVector of mouse position mapped to a sphere or
+     * Returns either the Jvector of mouse position mapped to a sphere or
      * the constrained version (when constrained to one axis) 
      * @param x
      * @param y
      * @return mouse coordinate mapped to unit sphere
      */
-    public JVector mouse2sphere(double x, double y) {
-        JVector v = new JVector((x - center_x) / radius, (y - center_y) / radius, 0);
+    public Jvector mouse2sphere(double x, double y) {
+        Jvector v = new Jvector((x - center_x) / radius, (y - center_y) / radius, 0);
         double mag_sq = v.x * v.x + v.y * v.y; 
         if (mag_sq > 1.0) {
             v.normalize(); 
@@ -215,8 +215,8 @@ public final class JArcBall {
      * @param axis
      * @return
      */
-    public JVector constrainVector(JVector vector, JVector axis) {
-        JVector res = vector.sub(axis.mult(axis.dot(vector)));
+    public Jvector constrainVector(Jvector vector, Jvector axis) {
+        Jvector res = vector.sub(axis.mult(axis.dot(vector)));
         return res.normalize(); // like Jvector res is changed
     }
 

--- a/ext/processing/vecmath/arcball/Jvector.java
+++ b/ext/processing/vecmath/arcball/Jvector.java
@@ -1,5 +1,5 @@
 /* 
- * Copyright (c) 2014 Martin Prout
+ * Copyright (c) 2015 Martin Prout
  * 
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,9 +23,9 @@ package processing.vecmath.arcball;
  *
  * @author Martin Prout
  */
-public final class JVector {
+public final class Jvector {
 
-    static final double EPSILON = 1.0e-04;
+    static final double EPSILON = 9.999999747378752e-05;
 
     /**
      *
@@ -48,7 +48,7 @@ public final class JVector {
      * @param y
      * @param z
      */
-    public JVector(double x, double y, double z) {
+    public Jvector(double x, double y, double z) {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -57,18 +57,17 @@ public final class JVector {
     /**
      *
      */
-    public JVector() {
+    public Jvector() {
         this(0.0f, 0.0f, 0.0f);
     }
-
 
      /**
       *
       * @param other
       * @return
       */
-     public JVector sub(JVector other) {
-         return new JVector(this.x - other.x, this.y - other.y, this.z - other.z);
+     public Jvector sub(Jvector other) {
+         return new Jvector(this.x - other.x, this.y - other.y, this.z - other.z);
      }
  
      /**
@@ -76,8 +75,8 @@ public final class JVector {
       * @param scalar
       * @return
       */
-     public JVector mult(double scalar) {
-         return new JVector(this.x * scalar, this.y * scalar, this.z * scalar);
+     public Jvector mult(double scalar) {
+         return new Jvector(this.x * scalar, this.y * scalar, this.z * scalar);
      }
 
     /**
@@ -93,7 +92,7 @@ public final class JVector {
      *
      * @return this
      */
-    public JVector normalize() {
+    public Jvector normalize() {
         double mag = Math.sqrt(x * x + y * y + z * z);
         this.x /= mag;
         this.y /= mag;
@@ -106,7 +105,7 @@ public final class JVector {
       * @param other
       * @return
       */
-     public double dot(JVector other) {
+     public double dot(Jvector other) {
          return x * other.x + y * other.y + z * other.z;
      }
  
@@ -115,11 +114,10 @@ public final class JVector {
       * @param other
       * @return
       */
-     public JVector cross(JVector other) {
+     public Jvector cross(Jvector other) {
          double xc = y * other.z - z * other.y;
          double yc = z * other.x - x * other.z;
          double zc = x * other.y - y * other.x;
-         return new JVector(xc, yc, zc);
-     }
-   
+         return new Jvector(xc, yc, zc);
+     }   
 }

--- a/ext/processing/vecmath/arcball/Quaternion.java
+++ b/ext/processing/vecmath/arcball/Quaternion.java
@@ -20,8 +20,6 @@
 
 package processing.vecmath.arcball;
 
-
-
 /**
  * Based on a original sketch by Ariel Malka
  * Arcball quaternion idea by Ken Shoemake
@@ -70,7 +68,7 @@ public final class Quaternion {
      * @param w scalar 
      * @param v custom Vector class
      */
-    public void set(double w, JVector v) {
+    public void set(double w, Jvector v) {
         this.w = w;
         x = v.x;
         y = v.y;
@@ -116,5 +114,3 @@ public final class Quaternion {
         return new double[]{Math.acos(w) * 2.0f, x / sa, y / sa, z / sa};
     }
 }
-
-

--- a/ext/processing/vecmath/arcball/Rarcball.java
+++ b/ext/processing/vecmath/arcball/Rarcball.java
@@ -55,17 +55,17 @@ public class Rarcball extends RubyObject {
             float cx = (float) args[1].toJava(Float.class);
             float cy = (float) args[2].toJava(Float.class);
             float radius = (float) args[3].toJava(Float.class);
-            new JArcBall(parent, cx, cy, radius).setActive(true);
+            new JarcBall(parent, cx, cy, radius).setActive(true);
         }
         if (count == 3) {
             PApplet parent = (PApplet) args[0].toJava(PApplet.class);
             float cx = (float) args[1].toJava(Float.class);
             float cy = (float) args[2].toJava(Float.class);
-            new JArcBall(parent, cx, cy, parent.width * 0.8f).setActive(true);
+            new JarcBall(parent, cx, cy, parent.width * 0.8f).setActive(true);
         }
         if (count == 1) {
             PApplet parent = (PApplet) args[0].toJava(PApplet.class);
-            new JArcBall(parent).setActive(true);
+            new JarcBall(parent).setActive(true);
         }        
     }
 }

--- a/ext/processing/vecmath/arcball/WheelHandler.java
+++ b/ext/processing/vecmath/arcball/WheelHandler.java
@@ -30,8 +30,7 @@ public interface WheelHandler {
     /**
      * 
      * @param amount 
-     */
-   
+     */   
 
     public void handleWheel(final int amount);
 }

--- a/ext/processing/vecmath/vec2/Vec2.java
+++ b/ext/processing/vecmath/vec2/Vec2.java
@@ -102,7 +102,7 @@ public class Vec2 extends RubyObject {
 
     public IRubyObject setX(ThreadContext context, IRubyObject other) {
         jx = (Double) other.toJava(Double.class);
-        return context.getRuntime().newFloat(jx);
+        return other;
     }
 
     /**
@@ -115,7 +115,7 @@ public class Vec2 extends RubyObject {
 
     public IRubyObject setY(ThreadContext context, IRubyObject other) {
         jy = (Double) other.toJava(Double.class);
-        return context.getRuntime().newFloat(jy);
+        return other;
     }
 
     /**

--- a/ext/processing/vecmath/vec3/Vec3.java
+++ b/ext/processing/vecmath/vec3/Vec3.java
@@ -120,7 +120,7 @@ public final class Vec3 extends RubyObject {
     
     public IRubyObject setX(ThreadContext context, IRubyObject other) {
         jx = (Double) other.toJava(Double.class);
-        return context.getRuntime().newFloat(jx);
+        return other;
     }
     
     /**
@@ -133,7 +133,7 @@ public final class Vec3 extends RubyObject {
     
     public IRubyObject setY(ThreadContext context, IRubyObject other) {
         jy = (Double) other.toJava(Double.class);
-        return context.getRuntime().newFloat(jy);
+        return other;
     }
     
     /**
@@ -145,7 +145,7 @@ public final class Vec3 extends RubyObject {
     @JRubyMethod(name = "z=")
     public IRubyObject setZ(ThreadContext context, IRubyObject other) {
         jz = (Double) other.toJava(Double.class);
-        return context.getRuntime().newFloat(jz);
+        return other;
     }
     
     /**

--- a/ext/processing/videoevent/VideoInterface.java
+++ b/ext/processing/videoevent/VideoInterface.java
@@ -1,0 +1,22 @@
+package processing.videoevent;
+import processing.video.Movie;
+import processing.video.Capture;
+/**
+ * This interface makes it easier/possible to use the reflection methods
+ * from Movie and Capture classes in Processing::App in ruby-processing
+ * @author Martin Prout
+ */
+public interface VideoInterface {
+    /**
+     * Used to implement reflection method in PApplet
+     * @see processing.video.Movie
+     * @param movie Movie
+     */
+    void movieEvent(Movie movie);
+    /**
+     * Used to implement reflection method in PApplet
+     * @see processing.video.Capture
+     * @param capture Capture
+     */
+    void captureEvent(Capture capture);    
+}

--- a/lib/ruby-processing.rb
+++ b/lib/ruby-processing.rb
@@ -14,15 +14,5 @@ require 'ruby-processing/helpers/range'
 
 # The top-level namespace, a home for all Ruby-Processing classes.
 module Processing
-  def self.exported?
-    @exported ||= ENV['EXPORTED'].eql?('true')
-  end
-
-  # Autoload a number of path/constants that we may end up using.
-  # mri ruby does not understand ** require 'java' ** and we may otherwise call
-  # it from mri ruby without lazy path loading of autoload
-  # NB: autoload is slated for possible removal by ruby-2.2
-  autoload :App,                  'ruby-processing/app'
-  autoload :Runner,               'ruby-processing/runner'
-  autoload :Watcher,              'ruby-processing/runners/watch'
+  require 'ruby-processing/runner'   
 end

--- a/lib/ruby-processing/app.rb
+++ b/lib/ruby-processing/app.rb
@@ -18,7 +18,9 @@ module Processing
   # should define in your sketch. 'setup' will be called one
   # time when the sketch is first loaded, and 'draw' will be
   # called constantly, for every frame.
-  Dir["#{RP_CONFIG["PROCESSING_ROOT"]}/core/library/\*.jar"].each { |jar| require jar }
+  Dir["#{RP_CONFIG["PROCESSING_ROOT"]}/core/library/\*.jar"].each do |jar| 
+    require jar unless jar =~ /native/
+  end
   # Include some core processing classes that we'd like to use:
   include_package 'processing.core'
 

--- a/lib/ruby-processing/app.rb
+++ b/lib/ruby-processing/app.rb
@@ -3,10 +3,12 @@
 # Most of the code here is for interfacing with Swing,
 # web applets, going fullscreen and so on.
 require 'java'
-require_relative '../ruby-processing/helper_methods'
-require_relative '../ruby-processing/helpers/string_extra'
-require_relative '../ruby-processing/library_loader'
-require_relative '../ruby-processing/config'
+require_relative 'helper_methods'
+require_relative 'helpers/string_extra'
+require_relative 'library_loader'
+require_relative 'config'
+
+
 
 module Processing
   # This is the main Ruby-Processing class, and is what you'll
@@ -16,7 +18,7 @@ module Processing
   # should define in your sketch. 'setup' will be called one
   # time when the sketch is first loaded, and 'draw' will be
   # called constantly, for every frame.
-
+  Dir["#{RP_CONFIG["PROCESSING_ROOT"]}/core/library/\*.jar"].each { |jar| require jar }
   # Include some core processing classes that we'd like to use:
   include_package 'processing.core'
 

--- a/lib/ruby-processing/config.rb
+++ b/lib/ruby-processing/config.rb
@@ -1,7 +1,8 @@
 require 'psych'
 
 module Processing
-  if Processing.exported?
+  
+  if ENV['EXPORTED'].eql?('true')
     RP_CONFIG = { 'PROCESSING_ROOT' => RP5_ROOT, 'JRUBY' => 'false' }
   end
   unless defined? RP_CONFIG

--- a/lib/ruby-processing/library_loader.rb
+++ b/lib/ruby-processing/library_loader.rb
@@ -1,7 +1,6 @@
-require_relative '../../lib/ruby-processing'
-require "#{RP5_ROOT}/lib/rpextras"
+# The processing wrapper module
+require_relative '../ruby-processing'
 
-# Then processing wrapper module
 module Processing
 
   # Encapsulate library loader functionality as a class
@@ -38,10 +37,10 @@ module Processing
     def load_ruby_library(library_name)
       library_name = library_name.to_sym
       return true if @loaded_libraries.include?(library_name)
-      if Processing.exported?
+      if ENV['EXPORTED'].eql?('true')
         begin
           return @loaded_libraries[library_name] = (require_relative "../library/#{library_name}")
-        rescue LoadError => e
+        rescue LoadError
           return false
         end
       end
@@ -63,7 +62,7 @@ module Processing
       jars.each { |jar| require jar }
       platform_specific_library_paths = get_platform_specific_library_paths(jpath)
       platform_specific_library_paths = platform_specific_library_paths.select do |ppath|
-        test(?d, ppath) && !Dir.glob(File.join(ppath, '*.{so,dll,jnilib}')).empty?
+        FileTest.directory?(ppath) && !Dir.glob(File.join(ppath, '*.{so,dll,jnilib}')).empty?
       end
       unless platform_specific_library_paths.empty?
         platform_specific_library_paths << java.lang.System.getProperty('java.library.path')
@@ -133,8 +132,8 @@ module Processing
        '.processing', 'sketchbook'].each do |prefix|
         spath = format('%s/%s', ENV['HOME'], prefix)
         pref_path = format('%s/preferences.txt', spath)
-        preferences_paths << pref_path if test(?f, pref_path)
-        sketchbook_paths << spath if test(?d, spath)
+        preferences_paths << pref_path if FileTest.file?(pref_path)
+        sketchbook_paths << spath if FileTest.directory?(spath)
       end
       return sketchbook_paths.first if preferences_paths.empty?
       lines = IO.readlines(preferences_paths.first)

--- a/lib/ruby-processing/library_loader.rb
+++ b/lib/ruby-processing/library_loader.rb
@@ -1,3 +1,6 @@
+require_relative '../../lib/ruby-processing'
+require "#{RP5_ROOT}/lib/rpextras"
+
 # Then processing wrapper module
 module Processing
 

--- a/lib/ruby-processing/runner.rb
+++ b/lib/ruby-processing/runner.rb
@@ -172,10 +172,6 @@ module Processing
 
     private
     
-    def core_classpath
-      Dir["#{Processing::RP_CONFIG['PROCESSING_ROOT']}/core/library/\*.jar"]
-    end
-
     # Trade in this Ruby instance for a JRuby instance, loading in a starter
     # script and passing it some arguments.Unless '--nojruby' is passed, the
     # installed version of jruby is used instead of our vendored jarred one
@@ -188,11 +184,10 @@ module Processing
       @options.nojruby = true if Processing::RP_CONFIG['JRUBY'] == 'false'
       java_args = discover_java_args(sketch)      
       if @options.nojruby
-        classpath = jruby_complete + core_classpath
         command = ['java',
                    java_args,
                    '-cp',
-                   classpath.join(path_separator),
+                   jruby_complete,
                    'org.jruby.Main',
                    runner,
                    sketch,
@@ -200,8 +195,6 @@ module Processing
       else
         command = ['jruby', 
                    java_args,
-                   '-J-cp',
-                   core_classpath.join(path_separator),
                    runner, 
                    sketch, 
                    args].flatten
@@ -209,11 +202,6 @@ module Processing
       exec(*command)
       # exec replaces the Ruby process with the JRuby one.
     end
-    
-    def path_separator
-      (host_os == :windows) ? ';' : ':'
-    end
-      
 
     # If you need to pass in arguments to Java, such as the ones on this page:
     # http://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/java.html
@@ -239,7 +227,7 @@ module Processing
 
     def jruby_complete
       rcomplete = File.join(RP5_ROOT, 'lib/ruby/jruby-complete.jar')
-      return [rcomplete] if FileTest.exist?(rcomplete)
+      return rcomplete if FileTest.exist?(rcomplete)
       warn "#{rcomplete} does not exist\nTry running `rp5 setup install`"
       exit
     end

--- a/lib/ruby-processing/runners/base.rb
+++ b/lib/ruby-processing/runners/base.rb
@@ -3,8 +3,8 @@
 SKETCH_PATH ||= ARGV.shift
 SKETCH_ROOT ||= File.dirname(SKETCH_PATH)
 
-require_relative '../../ruby-processing'
-require_relative '../../ruby-processing/app'
+# we can safely require app.rb as we are using a jruby runtime
+require_relative '../app'
 
 # More processing module
 module Processing

--- a/lib/ruby-processing/runners/live.rb
+++ b/lib/ruby-processing/runners/live.rb
@@ -2,7 +2,7 @@
 # This flavor will either load up empty Ruby-Processing,
 # or will start with your sketch.
 
-require_relative '../../ruby-processing/runners/base'
+require_relative 'base'
 Processing.load_and_run_sketch
 
 ARGV.clear # So that IRB doesn't try to load them as files.

--- a/lib/ruby-processing/runners/run.rb
+++ b/lib/ruby-processing/runners/run.rb
@@ -1,6 +1,3 @@
-# TODO: this is crud. Windows applets are having serious
-# trouble with absolute paths.
-
-require_relative '../runners/base'
+require_relative 'base'
 
 Processing.load_and_run_sketch

--- a/lib/ruby-processing/runners/watch.rb
+++ b/lib/ruby-processing/runners/watch.rb
@@ -1,4 +1,4 @@
-require_relative '../runners/base'
+require_relative 'base'
 
 module Processing
   # A sketch loader, observer, and reloader, to tighten

--- a/lib/ruby-processing/version.rb
+++ b/lib/ruby-processing/version.rb
@@ -1,3 +1,3 @@
 module RubyProcessing
-  VERSION = '2.6.13'
+  VERSION = '2.6.14.pre'
 end

--- a/library/fastmath/fastmath.rb
+++ b/library/fastmath/fastmath.rb
@@ -1,3 +1,4 @@
-require 'rpextras'
+require_relative '../../lib/ruby-processing'
+require "#{RP5_ROOT}/lib/rpextras"
 
 Java::ProcessingFastmath::DeglutLibrary.new.load(JRuby.runtime, false)

--- a/library/library_proxy/library_proxy.rb
+++ b/library/library_proxy/library_proxy.rb
@@ -1,4 +1,5 @@
-require 'rpextras'
+require_relative '../../lib/ruby-processing'
+require "#{RP5_ROOT}/lib/rpextras"
 
 LibraryProxy = Java::ProcessingCore::AbstractLibrary
 

--- a/library/vecmath/vecmath.rb
+++ b/library/vecmath/vecmath.rb
@@ -1,8 +1,5 @@
-require 'rpextras'
-
-# HACK: required for exported applications, comment out or replace first line
-# with next line (create a lib folder here and move rpextras.jar there.
-# require_relative 'lib/rpextras'
+require_relative '../../lib/ruby-processing'
+require "#{RP5_ROOT}/lib/rpextras"
 
 Java::ProcessingVecmathArcball::ArcballLibrary.new.load(JRuby.runtime, false)
 Java::ProcessingVecmathVec2::Vec2Library.new.load(JRuby.runtime, false)

--- a/library/vecmath/vecmath.rb
+++ b/library/vecmath/vecmath.rb
@@ -1,9 +1,21 @@
 require_relative '../../lib/ruby-processing'
 require "#{RP5_ROOT}/lib/rpextras"
 
-Java::ProcessingVecmathArcball::ArcballLibrary.new.load(JRuby.runtime, false)
 Java::ProcessingVecmathVec2::Vec2Library.new.load(JRuby.runtime, false)
 Java::ProcessingVecmathVec3::Vec3Library.new.load(JRuby.runtime, false)
 
 AppRender = Java::ProcessingVecmath::AppRender
 ShapeRender = Java::ProcessingVecmath::ShapeRender
+# see runner.rb where rpextras gets loaded see ext for java classes
+module Processing
+  # Access the built in ArcBall funtionality
+  class ArcBall
+    def self.init app, center_x = nil, center_y = nil, radius = nil
+      x = center_x.nil? ? app.width * 0.5 : center_x
+      y = center_y.nil? ? app.height * 0.5 : center_y
+      r = radius.nil? ? app.height * 0.5 : radius
+      arcball = Java::ProcessingArcball::Arcball.new(app.to_java, x.to_java(:float), y.to_java(:float), r.to_java(:float))
+      arcball.set_active true
+    end
+  end
+end

--- a/library/video_event/video_event.rb
+++ b/library/video_event/video_event.rb
@@ -2,7 +2,7 @@ require_relative '../../lib/ruby-processing'
 require "#{RP5_ROOT}/lib/rpextras"
 
 class Processing::App
-  include Java::ProcessingCore::VideoInterface
+  include Java::ProcessingVideoevent::VideoInterface
   def captureEvent(c)
     # satisfy implement abstract class
   end

--- a/library/video_event/video_event.rb
+++ b/library/video_event/video_event.rb
@@ -1,4 +1,5 @@
-require 'rpextras'
+require_relative '../../lib/ruby-processing'
+require "#{RP5_ROOT}/lib/rpextras"
 
 class Processing::App
   include Java::ProcessingCore::VideoInterface

--- a/vendors/Rakefile
+++ b/vendors/Rakefile
@@ -8,7 +8,7 @@ WARNING = <<-EOS
       
 EOS
 
-JRUBYC_VERSION     = '1.7.20'
+JRUBYC_VERSION     = '1.7.21'
 EXAMPLES           = '1.6'
 HOME_DIR = ENV['HOME']
 MAC_OR_LINUX = /linux|mac|darwin/ =~ RbConfig::CONFIG['host_os'] 
@@ -27,7 +27,7 @@ file "jruby-complete-#{JRUBYC_VERSION}.jar" do
   rescue
     warn(WARNING)
   end
-  check_sha1("jruby-complete-#{JRUBYC_VERSION}.jar", "0f784b3d9d760b80b2f9d78ede80ee1d8d85e786")
+  check_sha1("jruby-complete-#{JRUBYC_VERSION}.jar", "e061b9f399a5e8d5cfcca84d4a6baf879111e83c")
 end
 
 directory "../lib/ruby"


### PR DESCRIPTION
Changes to make ruby-processing compatible with jruby-9.0.0.0 (mainly means loading native libraries to java classpath at runtime) however this fix does not solve all incompatibilities. Which is why we jruby version check, to avoid fix unless required, and running with jruby-complete should not be affected.