### PR TITLE
Adds the run-app command to override the sketch wrapping

### DIFF
--- a/lib/ruby-processing/app.rb
+++ b/lib/ruby-processing/app.rb
@@ -158,7 +158,7 @@ module Processing
       klass.constants.each do |name|
         const = klass.const_get name
         next if const.class != Class || const.to_s.match(/^Java::/)
-        const.class_eval 'include Processing::Proxy'
+        const.class_eval('include Processing::Proxy')
       end
     end
 

--- a/lib/ruby-processing/runner.rb
+++ b/lib/ruby-processing/runner.rb
@@ -33,6 +33,7 @@ module Processing
     Examples:
     rp5 setup unpack_samples
     rp5 run rp_samples/samples/contributed/jwishy.rb
+    rp5 run-app rp_samples/samples/contributed/jwishy.rb
     rp5 create some_new_sketch 640 480 p3d (P3D mode example)
     rp5 create some_new_sketch 640 480 --wrap (a class wrapped default sketch)
     rp5 watch some_new_sketch.rb
@@ -63,14 +64,15 @@ module Processing
     # Dispatch central.
     def execute!
       case @options.action
-      when 'run'    then run(@options.path, @options.args)
-      when 'watch'  then watch(@options.path, @options.args)
-      when 'live'   then live(@options.path, @options.args)
-      when 'create' then create(@options.path, @options.args)
-      when 'app'    then app(@options.path)
-      when 'setup'  then setup(@options.path)
-      when /-v/     then show_version
-      when /-h/     then show_help
+      when 'run'        then run(@options.path, @options.args)
+      when 'run-app'    then run_app(@options.path, @options.args)
+      when 'watch'      then watch(@options.path, @options.args)
+      when 'live'       then live(@options.path, @options.args)
+      when 'create'     then create(@options.path, @options.args)
+      when 'app'        then app(@options.path)
+      when 'setup'      then setup(@options.path)
+      when /-v/         then show_version
+      when /-h/         then show_help
       else
         show_help
       end
@@ -101,6 +103,11 @@ module Processing
     def run(sketch, args)
       ensure_exists(sketch)
       spin_up('run.rb', sketch, args)
+    end
+
+    def run_app(sketch, args)
+      ensure_exists(sketch)
+      spin_up('run_app.rb', sketch, args)
     end
 
     # Run a sketch, keeping an eye on it's file, and reloading

--- a/lib/ruby-processing/runners/base.rb
+++ b/lib/ruby-processing/runners/base.rb
@@ -26,18 +26,23 @@ module Processing
   EOS
 
   # This method is the common entry point to run a sketch, bare or complete.
+
+  def self.run_app
+      load SKETCH_PATH
+      Processing::App.sketch_class.new unless $app
+  end
+
   def self.load_and_run_sketch
     source = read_sketch_source
     wrapped = !source.match(/^[^#]*< Processing::App/).nil?
     no_methods = source.match(/^[^#]*(def\s+setup|def\s+draw)/).nil?
     if wrapped
-      load SKETCH_PATH
-      Processing::App.sketch_class.new unless $app
+      run_app
       return
     end
-    code = no_methods ? format(NAKED_WRAP, source) : format(BARE_WRAP, source)
-    Object.class_eval code, SKETCH_PATH, -1
+    Object.class_eval(code, SKETCH_PATH, -1)
     Processing::App.sketch_class.new
+    code = no_methods ? format(NAKED_WRAP, source) : format(BARE_WRAP, source)
   end
 
   # Read in the sketch source code. Needs to work both online and offline.

--- a/lib/ruby-processing/runners/run_app.rb
+++ b/lib/ruby-processing/runners/run_app.rb
@@ -1,0 +1,3 @@
+require_relative 'base'
+
+Processing.run_app


### PR DESCRIPTION
Adds a new option scoped for those who want to just want to build full jRuby apps that use Ruby Processing. It discards the whole Processing class wrapping logic.
